### PR TITLE
style: adjust the PR line item formatting for slack

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28130,6 +28130,7 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, f
   } else {
     if (hasPR) {
       if (formatForSlack) {
+        console.log('subject: ', subject);
         outputForSlack = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
           return `(PR <https://github.com/${owner}/${repo}/pull/${prId}|#${prId}> by <${authorUrl}|@${author}>)`

--- a/dist/index.js
+++ b/dist/index.js
@@ -28107,7 +28107,7 @@ const types = [
 const rePrId = /#([0-9]+)/g
 const rePrEnding = /\(#([0-9]+)\)$/
 
-function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, formatForSlack }) {
+function buildSubject ({ writeToFile, subject, author, authorUrl, commitScope, commitUrl, commitShaSubstr, owner, repo, formatForSlack }) {
   const hasPR = rePrEnding.test(subject)
   const prs = []
   let output = subject
@@ -28130,11 +28130,11 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, f
   } else {
     if (hasPR) {
       if (formatForSlack) {
-        console.log('subject: ', subject);
         outputForSlack = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
-          return `(PR <https://github.com/${owner}/${repo}/pull/${prId}|#${prId}> by <${authorUrl}|@${author}>)`
-        })
+          return `(<${commitUrl}|${commitShaSubstr}>, <${authorUrl}|@${author}>)`;
+        });
+        outputForSlack = `${commitScope ? `(${commitScope}) ` : ''}${outputForSlack}`;
       } else {
         output = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
@@ -28385,6 +28385,9 @@ async function main () {
         subject: commit.subject,
         author: commit.author,
         authorUrl: commit.authorUrl,
+        commitScope: commit.scope,
+        commitUrl: commit.url,
+        commitShaSubstr: commit.sha.substring(0, 7),
         formatForSlack,
         owner,
         repo
@@ -28392,7 +28395,9 @@ async function main () {
       changesFile.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectFile.output}`)
       changesVar.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectVar.output}`)
       if (formatForSlack) {
-        changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
+        console.log('outputForSlack: ', subjectVar.outputForSlack);
+        // changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
+        changesForSlack.push(`• ${subjectVar.outputForSlack}`)
       }
 
       if (includeRefIssues && subjectVar.prs.length > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -28395,8 +28395,6 @@ async function main () {
       changesFile.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectFile.output}`)
       changesVar.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectVar.output}`)
       if (formatForSlack) {
-        console.log('outputForSlack: ', subjectVar.outputForSlack);
-        // changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
         changesForSlack.push(`• ${subjectVar.outputForSlack}`)
       }
 

--- a/index.js
+++ b/index.js
@@ -310,8 +310,6 @@ async function main () {
       changesFile.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectFile.output}`)
       changesVar.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectVar.output}`)
       if (formatForSlack) {
-        console.log('outputForSlack: ', subjectVar.outputForSlack);
-        // changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
         changesForSlack.push(`• ${subjectVar.outputForSlack}`)
       }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const types = [
 const rePrId = /#([0-9]+)/g
 const rePrEnding = /\(#([0-9]+)\)$/
 
-function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, formatForSlack }) {
+function buildSubject ({ writeToFile, subject, author, authorUrl, commitScope, commitUrl, commitShaSubstr, owner, repo, formatForSlack }) {
   const hasPR = rePrEnding.test(subject)
   const prs = []
   let output = subject
@@ -45,11 +45,11 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, f
   } else {
     if (hasPR) {
       if (formatForSlack) {
-        console.log('subject: ', subject);
         outputForSlack = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
-          return `(PR <https://github.com/${owner}/${repo}/pull/${prId}|#${prId}> by <${authorUrl}|@${author}>)`
-        })
+          return `(<${commitUrl}|${commitShaSubstr}>, <${authorUrl}|@${author}>)`;
+        });
+        outputForSlack = `${commitScope ? `(${commitScope}) ` : ''}${outputForSlack}`;
       } else {
         output = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
@@ -300,6 +300,9 @@ async function main () {
         subject: commit.subject,
         author: commit.author,
         authorUrl: commit.authorUrl,
+        commitScope: commit.scope,
+        commitUrl: commit.url,
+        commitShaSubstr: commit.sha.substring(0, 7),
         formatForSlack,
         owner,
         repo
@@ -307,7 +310,9 @@ async function main () {
       changesFile.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectFile.output}`)
       changesVar.push(`- [\`${commit.sha.substring(0, 7)}\`](${commit.url}) - ${scope}${subjectVar.output}`)
       if (formatForSlack) {
-        changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
+        console.log('outputForSlack: ', subjectVar.outputForSlack);
+        // changesForSlack.push(`• <${commit.url}|\`${commit.sha.substring(0, 7)}\`> ${scope}${subjectVar.outputForSlack}`)
+        changesForSlack.push(`• ${subjectVar.outputForSlack}`)
       }
 
       if (includeRefIssues && subjectVar.prs.length > 0) {

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo, f
   } else {
     if (hasPR) {
       if (formatForSlack) {
+        console.log('subject: ', subject);
         outputForSlack = subject.replace(rePrEnding, (m, prId) => {
           prs.push(prId)
           return `(PR <https://github.com/${owner}/${repo}/pull/${prId}|#${prId}> by <${authorUrl}|@${author}>)`


### PR DESCRIPTION
As per feedback received by @milindalvares I've changed by formatting of the PR line items.
from:
<img width="326" alt="Screenshot 2023-01-17 at 12 26 53 PM" src="https://user-images.githubusercontent.com/4023331/212830373-0e009b70-0f03-46ae-9146-3cfa25a8b713.png">

to:
<img width="305" alt="Screenshot 2023-01-17 at 12 25 16 PM" src="https://user-images.githubusercontent.com/4023331/212830094-3402d409-bbfd-4186-8732-1b42c1fade2f.png">
